### PR TITLE
chore: update CycloneDX Python library

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -73,7 +73,7 @@ jobs:
             python-version: '3.10'
             toxenv-factor: 'locked'
           - # test with the lowest dependencies
-            python-version: '3.7'
+            python-version: '3.8'
             toxenv-factor: 'lowest'
     steps:
       - name: Checkout
@@ -113,12 +113,12 @@ jobs:
           - "3.10" # highest supported
           - "3.9"
           - "3.8"
-          - "3.7"  # lowest supported
+          - "3.8"  # lowest supported
         toxenv-factor: ['locked']
         include:
           - # test with the lowest dependencies
             os: 'ubuntu-latest'
-            python-version: '3.7'
+            python-version: '3.8'
             toxenv-factor: 'lowest'
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,21 +25,25 @@ classifiers = [
     'Topic :: Software Development',
     'Topic :: System :: Software Distribution',
     'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Typing :: Typed'
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 # ATTENTION: keep `requirements.lowest.txt` file in sync
-cyclonedx-python-lib = ">= 4.0.0rc1, < 5.0.0"
-packageurl-python = ">= 0.9"
-importlib-metadata = { version = ">= 3.4", python = "< 3.8" }
-ossindex-lib = "^1.1.1"
-osv-lib = "^0.2.1"
+cyclonedx-python-lib = "^8.0.0"
+packageurl-python = "^0.11"
+# Temporary until upstream ossindex-lib/osv-lib releases include relaxed packageurl-python constraints.
+ossindex-lib = "^1.2.0"
+osv-lib = "^0.3.0"
+types-requests = "<2.29"
 rich = "^12.4.4"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.lowest.txt
+++ b/requirements.lowest.txt
@@ -1,9 +1,10 @@
 # exactly pinned dependencies to the lowest version regardless of python_version
-# see pyptoject file for ranges
+# see pyproject file for ranges
 
-cyclonedx-python-lib == 4.0.0rc1
-packageurl-python == 0.9
-importlib-metadata == 3.4.0 # ; python_version < '3.8'
-ossindex-lib == 1.1.1
-osv-lib == 0.2.1
+cyclonedx-python-lib == 8.0.0
+packageurl-python == 0.11.1
+# Temporary until upstream ossindex-lib/osv-lib releases include relaxed packageurl-python constraints.
+ossindex-lib == 1.2.0
+osv-lib == 0.3.0
+types-requests == 2.28.11.15
 rich == 12.4.4

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ minversion = 3.10
 envlist =
     flake8
     mypy-{locked,lowest}
-    py{310,39,38,37}-{locked,lowest}
+    py{310,39,38}-{locked,lowest}
 isolated_build = True
 skip_missing_interpreters = True
 usedevelop = False
@@ -31,7 +31,7 @@ skip_install = True
 commands =
     # mypy config is on own file: `.mypy.ini`
     !lowest: poetry run mypy
-     lowest: poetry run mypy --python-version=3.7
+     lowest: poetry run mypy --python-version=3.8
 
 [testenv:flake8]
 skip_install = True

--- a/vexy/client.py
+++ b/vexy/client.py
@@ -21,21 +21,21 @@
 import argparse
 import enum
 import json
-import sys
 from datetime import datetime
-from importlib import import_module
+from importlib.metadata import version as meta_version
 from io import TextIOWrapper
 from os import getcwd, path
 from string import printable
-from typing import Dict, Optional, Set, cast
+from typing import Dict, Optional, Set
 from urllib.parse import quote
 from xml.etree import ElementTree
 
 import yaml
 from cyclonedx.exception import CycloneDxException
-from cyclonedx.model import ExternalReference, ExternalReferenceType, Tool, XsUri
+from cyclonedx.model import ExternalReference, ExternalReferenceType, XsUri
 from cyclonedx.model.bom import Bom
-from cyclonedx.output import BaseOutput
+from cyclonedx.model.tool import Tool
+from cyclonedx.output import BaseOutput, make_outputter
 from cyclonedx.schema import OutputFormat, SchemaVersion
 from rich.console import Console
 from rich.progress import Progress
@@ -51,18 +51,13 @@ class _CLI_OUTPUT_FORMAT(enum.Enum):
 
 
 _output_formats: Dict[_CLI_OUTPUT_FORMAT, OutputFormat] = {
-    _CLI_OUTPUT_FORMAT.XML: OutputFormat('Xml'),
-    _CLI_OUTPUT_FORMAT.JSON: OutputFormat('Json'),
+    _CLI_OUTPUT_FORMAT.XML: OutputFormat.XML,
+    _CLI_OUTPUT_FORMAT.JSON: OutputFormat.JSON,
 }
 _output_default_filenames = {
     _CLI_OUTPUT_FORMAT.XML: 'cyclonedx-vex.xml',
     _CLI_OUTPUT_FORMAT.JSON: 'cyclonedx-vex.json',
 }
-
-if sys.version_info >= (3, 8):
-    from importlib.metadata import version as meta_version
-else:
-    from importlib_metadata import version as meta_version
 
 try:
     __ThisToolVersion: Optional[str] = str(meta_version('vexy'))  # type: ignore[no-untyped-call]
@@ -172,7 +167,7 @@ class VexyCmd:
             )
 
             vex = Bom()
-            vex.metadata.tools.add(ThisTool)
+            vex.metadata.tools.tools.add(ThisTool)
             data_source_tasks = {}
             for data_source in self._data_sources:
                 data_source_tasks[data_source.__class__] = progress.add_task(
@@ -225,13 +220,7 @@ class VexyCmd:
         schema_version = SchemaVersion['V{}'.format(
             str(self._arguments.output_schema_version).replace('.', '_')
         )]
-        try:
-            module = import_module(f"cyclonedx.output.{self._arguments.output_format.lower()}")
-            output_klass = getattr(module, f"{output_format.value}{schema_version.value}")
-        except (ImportError, AttributeError):
-            raise ValueError(f"Unknown format {output_format.value.lower()!r}") from None
-
-        return cast(BaseOutput, output_klass(bom=bom))
+        return make_outputter(bom=bom, output_format=output_format, schema_version=schema_version)
 
     @staticmethod
     def get_arg_parser(*, prog: Optional[str] = None) -> argparse.ArgumentParser:

--- a/vexy/sources/ossindex.py
+++ b/vexy/sources/ossindex.py
@@ -52,7 +52,7 @@ class OssIndexSource(BaseSource):
     def get_vulnerabilities(self) -> Set[Vulnerability]:
         ossi = OssIndex(enable_cache=False)
         ossi_results = ossi.get_component_report(
-            packages=list(map(lambda c: c.purl, self.valid_components))
+            packages=[c.purl for c in self.valid_components if c.purl is not None]
         )
 
         vulnerabilities: Set[Vulnerability] = set()

--- a/vexy/sources/osv.py
+++ b/vexy/sources/osv.py
@@ -19,8 +19,9 @@
 
 from typing import Any, Dict, List, Set
 
-from cyclonedx.model import OrganizationalContact, XsUri
+from cyclonedx.model import XsUri
 from cyclonedx.model.component import Component
+from cyclonedx.model.contact import OrganizationalContact
 from cyclonedx.model.impact_analysis import ImpactAnalysisAffectedStatus
 from cyclonedx.model.vulnerability import (
     BomTarget,
@@ -47,6 +48,8 @@ class OsvSource(BaseSource):
         vulnerabilities: Set[Vulnerability] = set()
 
         for component in self.valid_components:
+            if component.bom_ref.value is None:
+                continue
             osv_vulnerabilities = osv.query(package=OsvPackage(purl=component.purl))
             for osv_v in osv_vulnerabilities:
                 affected_versions: List[BomTargetVersionRange] = []


### PR DESCRIPTION
## Summary

- updates Vexy for the newer cyclonedx-python-lib API
- relaxes packageurl-python-compatible dependency ranges through updated ossindex-lib and osv-lib releases
- drops Python 3.7 from the test matrix because the updated dependency set no longer supports it

## Validation

- Branch was rebased/pushed from dannysauer/vexy
- Local patch reviewed for dependency/API compatibility before opening

## Notes

This is part of cleaning up the old Vexy dependency stack. The upstream project appears quiet, but this PR keeps the change available for consideration.